### PR TITLE
Extensions to DocumentKit to provide splash screen functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,32 @@ struct MyOnboardingScreen: DocumentGroupModal {
     }
 }
 ```
+
+Additionally, DocumentKit extends `DocumentGroup` with a modifier that lets you present a splash screen each time the app runs - both with a configurable option to stop presenting it and options to configure when it is presented (delay) and when it is automatically dissmissed (dismiss):
+
+```swift
+@main
+struct DemoApp: App {
+
+    var body: some Scene {
+        DocumentGroup(newDocument: DemoDocument()) { file in
+            ContentView(document: file.$document)
+        }
+        .splashScreenSheet(delay: 0.5, dismiss: 3) {
+            MySplashScreen()
+        }
+    }
+}
+
+struct MySplashScreen: DocumentGroupModal {
+
+    var body: some View {
+        Text("Hello, Splishy Splash screen!")
+    }
+}
+```
  
-DeckKit also lets the `DocumentGroup` present any `DocumentGroupModal` as a sheet, a full screen cover, or using any UIKit-specific modal presentation type.
+DockKit also lets the `DocumentGroup` present any `DocumentGroupModal` as a sheet, a full screen cover, or using any UIKit-specific modal presentation type.
 
 For more information, please see the [online documentation][Documentation] and [getting started guide][Getting-Started] guide. 
 

--- a/Sources/DocumentKit/DocumentGroup+SplashScreen.swift
+++ b/Sources/DocumentKit/DocumentGroup+SplashScreen.swift
@@ -1,0 +1,112 @@
+//
+//  DocumentGroup+SplashScreen.swift
+//  WriterWriter
+//
+//  Created by Christopher Charles Cavnor on 9/24/23.
+//
+
+import SwiftUI
+
+public extension DocumentGroup {
+
+    /**
+     Present a splash screen sheet when the application starts.
+
+     The  splash screen will be presented each time the app starts, but
+     you can use the `UserDefaults` extensions to handle the
+     state of the  splash screen. You can use different `id`s to
+     present different  splash screens.
+
+     - Parameters:
+     - id: The  splash screen ID, by default `nil`.
+     - store: The persistency store, by default `.standard`.
+     - delay: The delay before presenting the  splash screen, by default `0.5`.
+     - dismiss: The delay before dismissing  the  splash screen, by default `1`.
+     - content: The  splash screen content.
+     */
+    func splashScreenSheet<Contents: DocumentGroupModal>(
+        id: String? = nil,
+        store: UserDefaults? = nil,
+        delay: TimeInterval? = nil,
+        dismiss: TimeInterval? = nil,
+        @ViewBuilder content: @escaping () -> Contents
+    ) -> DocumentGroup {
+        splashScreenModal(
+            id: id,
+            store: store,
+            delay: delay,
+            dismiss: dismiss,
+            presentation: { try $0.presentAsDocumentGroupSheet() },
+            content: content
+        )
+    }
+
+    /**
+     Present an  splash screen modal when the application starts.
+
+     The  splash screen will only be presented once, after which
+     you can use the `UserDefaults` extensions to handle the
+     state of the  splash screen. You can use different `id`s to
+     present different  splash screens.
+
+     - Parameters:
+     - id: The  splash screen ID, by default `nil`.
+     - store: The persistency store, by default `.standard`.
+     - delay: The delay before presenting the splash screen, by default `0.5`.
+     - dismiss: The delay before dismissing  the  splash screen, by default `1`.
+     - content: The  splash screen content.
+     */
+    func splashFullScreenCover<Contents: DocumentGroupModal>(
+        id: String? = nil,
+        store: UserDefaults? = nil,
+        delay: TimeInterval? = nil,
+        dismiss: TimeInterval? = nil,
+        @ViewBuilder content: @escaping () -> Contents
+    ) -> DocumentGroup {
+        splashScreenModal(
+            id: id,
+            store: store,
+            delay: delay,
+            dismiss: dismiss,
+            presentation: { try $0.presentAsDocumentGroupFullScreenCover() },
+            content: content
+        )
+    }
+}
+
+private extension DocumentGroup {
+
+    func splashScreenModal<Contents: DocumentGroupModal>(
+        id: String? = nil,
+        store: UserDefaults? = nil,
+        delay: TimeInterval? = nil,
+        dismiss: TimeInterval? = nil,
+        presentation: (Contents) throws -> Void,
+        @ViewBuilder content: @escaping () -> Contents
+    ) -> DocumentGroup {
+        let store = store ?? .standard
+        // ensure that delay is never set to 0 else app will crash
+        let delay = delay ?? delay == 0 ? 0.5 : delay!
+        // ensure that dismiss is greater than delay and lasts for at least 1 seconds (constitutes viewing time)
+        let dismiss = (dismiss ?? dismiss)! <= delay ? delay + 1 : dismiss!
+
+        print("delay=\(delay) and dismiss=\(dismiss)")
+
+        // show the splash screen
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+            do {
+                try content().presentAsDocumentGroupFullScreenCover()
+                store.setDocumentGroupSplashScreenState(to: true, for: id)
+            } catch {
+                // treating the splash screen as missoin critical
+                fatalError("*** Splash screen failed to execute: \(error) ***")
+            }
+        }
+        
+        // remove spash screen after delay
+        DispatchQueue.main.asyncAfter(deadline: .now() + dismiss) {
+            dismissCurrentDocument()
+        }
+        return self
+    }
+}

--- a/Sources/DocumentKit/UserDefaults+SplashScreen.swift
+++ b/Sources/DocumentKit/UserDefaults+SplashScreen.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+public extension UserDefaults {
+
+    /**
+     The default storage key for a document group splash screen.
+     */
+    var defaultDocumentGroupSplashScreenId: String {
+        "com.documentkit.isSplashScreenPresented"
+    }
+
+    /**
+     Get the state of a certain document group splash screen.
+     */
+    func documentGroupSplashScreenState(
+        for id: String? = nil
+    ) -> Bool {
+        bool(forKey: id ?? defaultDocumentGroupSplashScreenId)
+    }
+
+    /**
+     Reset the state of a certain document group splash screen.
+     */
+    func resetDocumentGroupSplashScreenState(
+        for id: String? = nil
+    ) {
+        setDocumentGroupSplashScreenState(to: false, for: id)
+    }
+
+    /**
+     Set the state of a certain document group splash screen.
+     */
+    func setDocumentGroupSplashScreenState(
+        to value: Bool,
+        for id: String? = nil
+    ) {
+        set(value, forKey: id ?? defaultDocumentGroupSplashScreenId)
+    }
+}


### PR DESCRIPTION
Added splash screen functionality. Updated README to reflect new functionality. Added checks to Onboarding and SplashScreen extensions to prevent passing a delay time of 0 - which crashes the app, and to ensure that the dismiss time for splash screen is one second ahead (by default) of delay time.